### PR TITLE
Qa 791 fix menu item media

### DIFF
--- a/src/main/java/org/broadleafcommerce/menu/admin/server/handler/MenuItemCustomPersistenceHandler.java
+++ b/src/main/java/org/broadleafcommerce/menu/admin/server/handler/MenuItemCustomPersistenceHandler.java
@@ -61,6 +61,11 @@ public class MenuItemCustomPersistenceHandler extends CustomPersistenceHandlerAd
     @Resource(name = "blMenuService")
     protected MenuService menuService;
 
+    /**
+     * When we are pulling back Media, the admin uses MenuItem for the ceiling entity class name,
+     * it should however be handled by the map structure module.  So only handle things in the MenuItem custom
+     * persistence handler for OperationType.BASIC
+     */
     @Override
     public Boolean canHandleInspect(PersistencePackage persistencePackage) {
         String ceilingEntityFullyQualifiedClassname = persistencePackage.getCeilingEntityFullyQualifiedClassname();

--- a/src/main/java/org/broadleafcommerce/menu/admin/server/handler/MenuItemCustomPersistenceHandler.java
+++ b/src/main/java/org/broadleafcommerce/menu/admin/server/handler/MenuItemCustomPersistenceHandler.java
@@ -22,6 +22,7 @@ package org.broadleafcommerce.menu.admin.server.handler;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.exception.ServiceException;
+import org.broadleafcommerce.common.presentation.client.OperationType;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.broadleafcommerce.menu.domain.MenuItem;
@@ -65,7 +66,8 @@ public class MenuItemCustomPersistenceHandler extends CustomPersistenceHandlerAd
         String ceilingEntityFullyQualifiedClassname = persistencePackage.getCeilingEntityFullyQualifiedClassname();
         try {
             Class testClass = Class.forName(ceilingEntityFullyQualifiedClassname);
-            return MenuItem.class.isAssignableFrom(testClass);
+            OperationType operationType = persistencePackage.getPersistencePerspective().getOperationTypes().getInspectType();
+            return MenuItem.class.isAssignableFrom(testClass) && OperationType.BASIC.equals(operationType);
         } catch (ClassNotFoundException e) {
             return false;
         }

--- a/src/main/java/org/broadleafcommerce/menu/domain/MenuItem.java
+++ b/src/main/java/org/broadleafcommerce/menu/domain/MenuItem.java
@@ -196,4 +196,11 @@ public interface MenuItem extends Serializable, MultiTenantCloneable<MenuItem> {
      */
     public String getDerivedLabel();
 
+    /**
+     * Convenience method that will always return the MenuItemType name.  Helpful if the MenuItemType
+     * has been overwritten.
+     *
+     * @return type
+     */
+    public String getMenuItemTypeName();
 }

--- a/src/main/java/org/broadleafcommerce/menu/domain/MenuItem.java
+++ b/src/main/java/org/broadleafcommerce/menu/domain/MenuItem.java
@@ -26,6 +26,7 @@ import org.broadleafcommerce.menu.type.MenuItemType;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.util.Map;
 
 
 public interface MenuItem extends Serializable, MultiTenantCloneable<MenuItem> {
@@ -80,16 +81,32 @@ public interface MenuItem extends Serializable, MultiTenantCloneable<MenuItem> {
     public void setActionUrl(String actionUrl);
 
     /**
-     * For items of type {@link MenuItemType#LINK}, gets any Media associated with this Menu Item
-     * @return
+     * Returns a map of key/value pairs where the key is a string for the name of a media object and the value
+     * is a media object.
+     * @deprecated use {@link #getMenuItemMediaXref()} instead
      */
-    public Media getImage();
+    @Deprecated
+    public Map<String, Media> getMenuItemMedia();
 
     /**
-     * For items of type {@link MenuItemType#LINK}, sets an Image for this Menu Item
-     * @param imageUrl
+    * Sets a map of key/value pairs where the key is a string for the name of a media object and the value
+    * is an object of type Media.
+    * @deprecated use {@link #setMenuItemMediaXref(java.util.Map)} instead
+    */
+    @Deprecated
+    public void setMenuItemMedia(Map<String, Media> menuItemMedia);
+
+    /**
+     * Returns a map of key/value pairs where the key is a string for the name of a media object and the value
+     * is a cross-reference to a media object.
      */
-    public void setImage(Media media);
+    public Map<String, MenuItemMediaXref> getMenuItemMediaXref();
+
+    /**
+     * Sets a map of key/value pairs where the key is a string for the name of a media object and the value
+     * is a cross-reference object to type Media.
+     */
+    public void setMenuItemMediaXref(Map<String, MenuItemMediaXref> menuItemMedia);
 
     /**
      * Returns the {@link Menu} to which this menuItem belongs

--- a/src/main/java/org/broadleafcommerce/menu/domain/MenuItemImpl.java
+++ b/src/main/java/org/broadleafcommerce/menu/domain/MenuItemImpl.java
@@ -49,7 +49,20 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.MapKey;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import javax.persistence.Transient;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)

--- a/src/main/java/org/broadleafcommerce/menu/domain/MenuItemImpl.java
+++ b/src/main/java/org/broadleafcommerce/menu/domain/MenuItemImpl.java
@@ -139,7 +139,7 @@ public class MenuItemImpl implements MenuItem, ProfileEntity {
                                     order = Presentation.FieldOrder.IMAGE_URL)
                     )
             })
-    private Map<String, MenuItemMediaXref> menuItemMedia = new HashMap<String, MenuItemMediaXref>();
+    protected Map<String, MenuItemMediaXref> menuItemMedia = new HashMap<String, MenuItemMediaXref>();
 
     @Transient
     protected Map<String, Media> legacyMenuItemMedia = new HashMap<String, Media>();

--- a/src/main/java/org/broadleafcommerce/menu/domain/MenuItemImpl.java
+++ b/src/main/java/org/broadleafcommerce/menu/domain/MenuItemImpl.java
@@ -329,6 +329,11 @@ public class MenuItemImpl implements MenuItem, ProfileEntity {
     }
 
     @Override
+    public String getMenuItemTypeName() {
+        return type;
+    }
+
+    @Override
     public <G extends MenuItem> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
         CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
         if (createResponse.isAlreadyPopulated()) {

--- a/src/main/java/org/broadleafcommerce/menu/domain/MenuItemImpl.java
+++ b/src/main/java/org/broadleafcommerce/menu/domain/MenuItemImpl.java
@@ -29,9 +29,11 @@ import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTy
 import org.broadleafcommerce.common.extensibility.jpa.copy.ProfileEntity;
 import org.broadleafcommerce.common.i18n.service.DynamicTranslationProvider;
 import org.broadleafcommerce.common.media.domain.Media;
-import org.broadleafcommerce.common.media.domain.MediaImpl;
 import org.broadleafcommerce.common.presentation.AdminPresentation;
 import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.AdminPresentationMap;
+import org.broadleafcommerce.common.presentation.AdminPresentationMapField;
+import org.broadleafcommerce.common.presentation.AdminPresentationMapFields;
 import org.broadleafcommerce.common.presentation.AdminPresentationToOneLookup;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
@@ -43,18 +45,11 @@ import org.hibernate.annotations.Parameter;
 import org.hibernate.annotations.Type;
 
 import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Inheritance;
-import javax.persistence.InheritanceType;
-import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)
@@ -111,12 +106,30 @@ public class MenuItemImpl implements MenuItem, ProfileEntity {
             order = Presentation.FieldOrder.ACTION_URL)
     protected String actionUrl;
 
-    @ManyToOne(targetEntity = MediaImpl.class)
-    @JoinColumn(name = "MEDIA_ID")
-    @AdminPresentation(friendlyName = "MenuItemImpl_Image",
-            fieldType = SupportedFieldType.MEDIA,
-            order = Presentation.FieldOrder.IMAGE_URL)
-    protected Media image;
+    @OneToMany(mappedBy = "menuItem", targetEntity = MenuItemMediaXrefImpl.class, cascade = { javax.persistence.CascadeType.ALL }, orphanRemoval = true)
+    @MapKey(name = "key")
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region = "blCMSElements")
+    @AdminPresentationMap(friendlyName = "MenuItemImpl_Media",
+            keyPropertyFriendlyName = "MenuItemImpl_Media_Key",
+            deleteEntityUponRemove = true,
+            mediaField = "media.url",
+            toOneTargetProperty = "media",
+            toOneParentProperty = "menuItem",
+            forceFreeFormKeys = true
+    )
+    @AdminPresentationMapFields(
+            mapDisplayFields = {
+                    @AdminPresentationMapField(
+                            fieldName = "primary",
+                            fieldPresentation = @AdminPresentation(friendlyName = "MenuItemImpl_Image",
+                                    fieldType = SupportedFieldType.MEDIA,
+                                    order = Presentation.FieldOrder.IMAGE_URL)
+                    )
+            })
+    private Map<String, MenuItemMediaXref> menuItemMedia = new HashMap<String, MenuItemMediaXref>();
+
+    @Transient
+    protected Map<String, Media> legacyMenuItemMedia = new HashMap<String, Media>();
 
     @Column(name = "ALT_TEXT")
     @AdminPresentation(friendlyName = "MenuItemImpl_AltText",
@@ -187,13 +200,34 @@ public class MenuItemImpl implements MenuItem, ProfileEntity {
     }
 
     @Override
-    public Media getImage() {
-        return image;
+    @Deprecated
+    public Map<String, Media> getMenuItemMedia() {
+        if (legacyMenuItemMedia.size() == 0) {
+            for (Map.Entry<String, MenuItemMediaXref> entry : getMenuItemMediaXref().entrySet()) {
+                legacyMenuItemMedia.put(entry.getKey(), entry.getValue().getMedia());
+            }
+        }
+        return Collections.unmodifiableMap(legacyMenuItemMedia);
     }
 
     @Override
-    public void setImage(Media image) {
-        this.image = image;
+    @Deprecated
+    public void setMenuItemMedia(Map<String, Media> menuItemMedia) {
+        this.menuItemMedia.clear();
+        this.legacyMenuItemMedia.clear();
+        for(Map.Entry<String, Media> entry : menuItemMedia.entrySet()){
+            this.menuItemMedia.put(entry.getKey(), new MenuItemMediaXrefImpl(this, entry.getValue(), entry.getKey()));
+        }
+    }
+
+    @Override
+    public Map<String, MenuItemMediaXref> getMenuItemMediaXref() {
+        return menuItemMedia;
+    }
+
+    @Override
+    public void setMenuItemMediaXref(Map<String, MenuItemMediaXref> menuItemMedia) {
+        this.menuItemMedia = menuItemMedia;
     }
 
     @Override
@@ -295,8 +329,9 @@ public class MenuItemImpl implements MenuItem, ProfileEntity {
             cloned.setParentMenu(parentMenu.createOrRetrieveCopyInstance(context).getClone());
         }
         cloned.setActionUrl(actionUrl);
-        if (image != null) {
-            cloned.setImage(((MediaImpl) image).createOrRetrieveCopyInstance(context).getClone());
+        for(Map.Entry<String, MenuItemMediaXref> entry : menuItemMedia.entrySet()){
+            MenuItemMediaXrefImpl clonedEntry = (MenuItemMediaXrefImpl) ((MenuItemMediaXrefImpl)entry.getValue()).createOrRetrieveCopyInstance(context).getClone();
+            cloned.getMenuItemMediaXref().put(entry.getKey(),clonedEntry);
         }
         cloned.setAltText(altText);
         if (linkedMenu != null) {

--- a/src/main/java/org/broadleafcommerce/menu/domain/MenuItemMediaXref.java
+++ b/src/main/java/org/broadleafcommerce/menu/domain/MenuItemMediaXref.java
@@ -1,0 +1,47 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2014 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.broadleafcommerce.menu.domain;
+
+import org.broadleafcommerce.common.media.domain.Media;
+
+import java.io.Serializable;
+
+/**
+ * @author Jon Fleschler
+ */
+public interface MenuItemMediaXref extends Serializable{
+
+    Long getId();
+
+    void setId(Long id);
+
+    MenuItem getMenuItem();
+
+    void setMenuItem(MenuItem menuItem);
+
+    Media getMedia();
+
+    void setMedia(Media media);
+
+    String getKey();
+
+    void setKey(String key);
+
+}

--- a/src/main/java/org/broadleafcommerce/menu/domain/MenuItemMediaXrefImpl.java
+++ b/src/main/java/org/broadleafcommerce/menu/domain/MenuItemMediaXrefImpl.java
@@ -38,7 +38,16 @@ import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
 
-import javax.persistence.*;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
 @Entity
 @Inheritance(strategy = InheritanceType.JOINED)

--- a/src/main/java/org/broadleafcommerce/menu/domain/MenuItemMediaXrefImpl.java
+++ b/src/main/java/org/broadleafcommerce/menu/domain/MenuItemMediaXrefImpl.java
@@ -1,0 +1,224 @@
+/*
+ * #%L
+ * BroadleafCommerce Framework
+ * %%
+ * Copyright (C) 2009 - 2013 Broadleaf Commerce
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.broadleafcommerce.menu.domain;
+
+import org.broadleafcommerce.common.copy.CreateResponse;
+import org.broadleafcommerce.common.copy.MultiTenantCloneable;
+import org.broadleafcommerce.common.copy.MultiTenantCopyContext;
+import org.broadleafcommerce.common.extensibility.jpa.clone.ClonePolicy;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransform;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformMember;
+import org.broadleafcommerce.common.extensibility.jpa.copy.DirectCopyTransformTypes;
+import org.broadleafcommerce.common.media.domain.Media;
+import org.broadleafcommerce.common.media.domain.MediaImpl;
+import org.broadleafcommerce.common.presentation.AdminPresentation;
+import org.broadleafcommerce.common.presentation.AdminPresentationClass;
+import org.broadleafcommerce.common.presentation.PopulateToOneFieldsEnum;
+import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
+import org.broadleafcommerce.common.util.UnknownUnwrapTypeException;
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.hibernate.annotations.GenericGenerator;
+import org.hibernate.annotations.Parameter;
+
+import javax.persistence.*;
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@Table(name = "BLC_CMS_MENU_ITEM_MEDIA_MAP")
+@Cache(usage = CacheConcurrencyStrategy.READ_WRITE, region="blCMSElements")
+@AdminPresentationClass(excludeFromPolymorphism = false, populateToOneFields = PopulateToOneFieldsEnum.TRUE)
+@DirectCopyTransform({
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.SANDBOX, skipOverlaps=true),
+        @DirectCopyTransformMember(templateTokens = DirectCopyTransformTypes.MULTITENANT_SITE)
+})
+public class MenuItemMediaXrefImpl implements MenuItemMediaXref, Media, MultiTenantCloneable<MenuItemMediaXref> {
+
+    /** The Constant serialVersionUID. */
+    private static final long serialVersionUID = 1L;
+
+    public MenuItemMediaXrefImpl(MenuItem menuItem, Media media, String key) {
+        this.menuItem = menuItem;
+        this.media = media;
+        this.key = key;
+    }
+
+    public MenuItemMediaXrefImpl() {
+        //support default constructor for Hibernate
+    }
+
+    @Id
+    @GeneratedValue(generator= "MenuItemMediaId")
+    @GenericGenerator(
+        name="MenuItemMediaId",
+        strategy="org.broadleafcommerce.common.persistence.IdOverrideTableGenerator",
+        parameters = {
+            @Parameter(name="segment_value", value="MenuItemMediaXrefImpl"),
+            @Parameter(name="entity_name", value="org.broadleafcommerce.menu.domain.MenuItemMediaXrefImpl")
+        }
+    )
+    @Column(name = "MENU_ITEM_MEDIA_ID")
+    protected Long id;
+
+    //for the basic collection join entity - don't pre-instantiate the reference (i.e. don't do myField = new MyFieldImpl())
+    @ManyToOne(targetEntity = MenuItemImpl.class, optional=false, cascade = CascadeType.REFRESH)
+    @JoinColumn(name = "MENU_ITEM_ID")
+    @AdminPresentation(excluded = true)
+    protected MenuItem menuItem;
+
+    //for the basic collection join entity - don't pre-instantiate the reference (i.e. don't do myField = new MyFieldImpl())
+    @ManyToOne(targetEntity = MediaImpl.class, cascade = {CascadeType.ALL})
+    @JoinColumn(name = "MEDIA_ID")
+    @ClonePolicy
+    protected Media media;
+
+    @Column(name = "MAP_KEY", nullable=false)
+    @AdminPresentation(visibility = VisibilityEnum.HIDDEN_ALL)
+    protected String key;
+
+    @Override
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @Override
+    public MenuItem getMenuItem() {
+        return menuItem;
+    }
+
+    @Override
+    public void setMenuItem(MenuItem menuItem) {
+        this.menuItem = menuItem;
+    }
+
+    @Override
+    public Media getMedia() {
+        return media;
+    }
+
+    @Override
+    public void setMedia(Media media) {
+        this.media = media;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    @Override
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String getUrl() {
+        createEntityInstance();
+        return media.getUrl();
+    }
+
+    @Override
+    public void setUrl(String url) {
+        createEntityInstance();
+        media.setUrl(url);
+    }
+
+    @Override
+    public String getTitle() {
+        createEntityInstance();
+        return media.getTitle();
+    }
+
+    @Override
+    public void setTitle(String title) {
+        createEntityInstance();
+        media.setTitle(title);
+    }
+
+    @Override
+    public String getAltText() {
+        createEntityInstance();
+        return media.getAltText();
+    }
+
+    @Override
+    public void setAltText(String altText) {
+        createEntityInstance();
+        media.setAltText(altText);
+    }
+
+    @Override
+    public String getTags() {
+        createEntityInstance();
+        return media.getTags();
+    }
+
+    @Override
+    public void setTags(String tags) {
+        createEntityInstance();
+        media.setTags(tags);
+    }
+
+    protected void createEntityInstance() {
+        if (media == null) {
+            media = new MediaImpl();
+        }
+    }
+
+    @Override
+    public boolean isUnwrappableAs(Class unwrapType) {
+        return Media.class.equals(unwrapType);
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> unwrapType) {
+        if (isUnwrappableAs(unwrapType)) {
+            return (T) media;
+        }
+        throw new UnknownUnwrapTypeException(unwrapType);
+    }
+
+    @Override
+    public <G extends MenuItemMediaXref> CreateResponse<G> createOrRetrieveCopyInstance(MultiTenantCopyContext context) throws CloneNotSupportedException {
+        CreateResponse<G> createResponse = context.createOrRetrieveCopyInstance(this);
+        if (createResponse.isAlreadyPopulated()) {
+            return createResponse;
+        }
+
+        MenuItemMediaXrefImpl cloned = (MenuItemMediaXrefImpl)createResponse.getClone();
+        if (media != null) {
+            cloned.setMedia(((MediaImpl) media).createOrRetrieveCopyInstance(context).getClone());
+        }
+        cloned.setAltText(getAltText());
+        cloned.setKey(key);
+        if (menuItem != null) {
+            cloned.setMenuItem(menuItem.createOrRetrieveCopyInstance(context).getClone());
+        }
+        cloned.setTags(getTags());
+        cloned.setUrl(getUrl());
+        cloned.setTitle(getTitle());
+        return createResponse;
+    }
+}

--- a/src/main/java/org/broadleafcommerce/menu/dto/MenuItemDTO.java
+++ b/src/main/java/org/broadleafcommerce/menu/dto/MenuItemDTO.java
@@ -34,11 +34,21 @@ public class MenuItemDTO implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
+    protected String type;
     protected String label;
     protected String url;
     protected String imageUrl;
     protected String altText;
+    protected String customHtml;
     protected List<MenuItemDTO> submenu = new ArrayList<MenuItemDTO>();
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
 
     public String getLabel() {
         return label;
@@ -70,6 +80,14 @@ public class MenuItemDTO implements Serializable {
 
     public void setAltText(String altText) {
         this.altText = altText;
+    }
+
+    public String getCustomHtml() {
+        return customHtml;
+    }
+
+    public void setCustomHtml(String customHtml) {
+        this.customHtml = customHtml;
     }
 
     public List<MenuItemDTO> getSubmenu() {

--- a/src/main/java/org/broadleafcommerce/menu/service/MenuServiceImpl.java
+++ b/src/main/java/org/broadleafcommerce/menu/service/MenuServiceImpl.java
@@ -99,8 +99,8 @@ public class MenuServiceImpl implements MenuService {
             MenuItemDTO dto = new MenuItemDTO();
             dto.setUrl(menuItem.getDerivedUrl());
             dto.setLabel(menuItem.getDerivedLabel());
-            if (menuItem.getImage() != null) {
-                dto.setImageUrl(menuItem.getImage().getUrl());
+            if (menuItem.getMenuItemMedia() != null) {
+                dto.setImageUrl(menuItem.getMenuItemMedia().get("primary").getUrl());
                 dto.setAltText(menuItem.getAltText());
             }
             return dto;

--- a/src/main/java/org/broadleafcommerce/menu/service/MenuServiceImpl.java
+++ b/src/main/java/org/broadleafcommerce/menu/service/MenuServiceImpl.java
@@ -80,6 +80,7 @@ public class MenuServiceImpl implements MenuService {
         if (MenuItemType.SUBMENU.equals(menuItem.getMenuItemType()) &&
                 menuItem.getLinkedMenu() != null) {
             MenuItemDTO dto = new MenuItemDTO();
+            dto.setType(menuItem.getMenuItemTypeName());
             dto.setUrl(menuItem.getDerivedUrl());
             dto.setLabel(menuItem.getDerivedLabel());
 
@@ -97,9 +98,11 @@ public class MenuServiceImpl implements MenuService {
             return convertCategoryToMenuItemDTO(category);
         } else {
             MenuItemDTO dto = new MenuItemDTO();
+            dto.setType(menuItem.getMenuItemTypeName());
             dto.setUrl(menuItem.getDerivedUrl());
             dto.setLabel(menuItem.getDerivedLabel());
-            if (menuItem.getMenuItemMedia() != null) {
+            dto.setCustomHtml(menuItem.getCustomHtml());
+            if (menuItem.getMenuItemMedia().size() > 0) {
                 dto.setImageUrl(menuItem.getMenuItemMedia().get("primary").getUrl());
                 dto.setAltText(menuItem.getAltText());
             }

--- a/src/main/resources/META-INF/persistence-menu.xml
+++ b/src/main/resources/META-INF/persistence-menu.xml
@@ -29,6 +29,7 @@
                 
         <class>org.broadleafcommerce.menu.domain.MenuImpl</class>
         <class>org.broadleafcommerce.menu.domain.MenuItemImpl</class>
+        <class>org.broadleafcommerce.menu.domain.MenuItemMediaXrefImpl</class>
         <exclude-unlisted-classes/>
     </persistence-unit>
 </persistence>

--- a/src/main/resources/menu/js/admin/menuItem.js
+++ b/src/main/resources/menu/js/admin/menuItem.js
@@ -38,6 +38,7 @@
             var menuItemType = $("#fields\\'type\\'\\.value", $form).val()
 
             // Initialize relevant fields
+            var $menuItemMedia    = $form.find('#menuItemMedia');
             var $actionUrl        = $form.find('#field-actionUrl');
             var $image            = $form.find('#field-image');
             var $altText          = $form.find('#field-altText');
@@ -48,6 +49,7 @@
             var $customHtml       = $form.find('#field-customHtml');
 
             // Hide everything
+            $menuItemMedia.addClass('hidden');
             $actionUrl.addClass('hidden');
             $image.addClass('hidden');
             $altText.addClass('hidden');


### PR DESCRIPTION
The `MenuItemImpl` needed to be updated to the new way of attaching `Media`.
I have created a new `MenuItemMediaXref` class and made the necessary changes to `MenuItemImpl`.

When creating a new `MenuItem` for a `Menu`, the save would fail when selecting the "Link" `MenuItemType` and attaching an Image.

Steps to recreate:
Login to admin
Go to Content -> Menus -> Select "Header nav"
Click Add under MenuItems
Change Type to Link
Fill out all information and select an image.
Click Save button. The error appears.

QA Issue: https://github.com/BroadleafCommerce/QA/issues/791
