### PR TITLE
Use compatible PersistenceModule for PersistencePackages

### DIFF
--- a/src/main/java/org/broadleafcommerce/menu/admin/server/handler/MenuItemCustomPersistenceHandler.java
+++ b/src/main/java/org/broadleafcommerce/menu/admin/server/handler/MenuItemCustomPersistenceHandler.java
@@ -22,6 +22,7 @@ package org.broadleafcommerce.menu.admin.server.handler;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.broadleafcommerce.common.exception.ServiceException;
+import org.broadleafcommerce.common.presentation.client.OperationType;
 import org.broadleafcommerce.common.presentation.client.SupportedFieldType;
 import org.broadleafcommerce.common.presentation.client.VisibilityEnum;
 import org.broadleafcommerce.menu.domain.MenuItem;
@@ -41,6 +42,7 @@ import org.broadleafcommerce.openadmin.server.dao.DynamicEntityDao;
 import org.broadleafcommerce.openadmin.server.service.handler.CustomPersistenceHandlerAdapter;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.BasicPersistenceModule;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.InspectHelper;
+import org.broadleafcommerce.openadmin.server.service.persistence.module.PersistenceModule;
 import org.broadleafcommerce.openadmin.server.service.persistence.module.RecordHelper;
 import org.springframework.stereotype.Component;
 import java.util.HashMap;
@@ -121,7 +123,9 @@ public class MenuItemCustomPersistenceHandler extends CustomPersistenceHandlerAd
 
     @Override
     public DynamicResultSet fetch(PersistencePackage persistencePackage, CriteriaTransferObject cto, DynamicEntityDao dynamicEntityDao, RecordHelper helper) throws ServiceException {
-        DynamicResultSet drs = ((BasicPersistenceModule) helper).fetch(persistencePackage, cto);
+        OperationType fetchType = persistencePackage.getPersistencePerspective().getOperationTypes().getFetchType();
+        PersistenceModule persistenceModule = helper.getCompatibleModule(fetchType);
+        DynamicResultSet drs = persistenceModule.fetch(persistencePackage, cto);
 
         for (Entity entity : drs.getRecords()) {
             Property menuItemId = entity.findProperty("id");


### PR DESCRIPTION
- Addresses Broadleafcommerce/QA#1245

<h2>Problem</h2>

PersistenceHandler is using the BasicPersistenceModule instead of using the PersistenceModule that is compatible with the passed in PersistencePackage.

<h2>Solution</h2>

Use the PersistenceModule that is compatible with the OperationType specified by the `PersistencePackage`.
