### PR TITLE
Refactored menu items to exclude missing categories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
     <artifactId>broadleaf-menu</artifactId>
     <name>BroadleafCommerce Menu</name>
     <description>BroadleafCommerce Menu</description>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.0.2-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <blc.version>5.1.0-SNAPSHOT</blc.version>
+        <blc.version>5.0.0-GA</blc.version>
         <project.uri>${project.baseUri}</project.uri>
         <attachSources>false</attachSources>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,10 @@
     <artifactId>broadleaf-menu</artifactId>
     <name>BroadleafCommerce Menu</name>
     <description>BroadleafCommerce Menu</description>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <blc.version>5.0.0-GA</blc.version>
+        <blc.version>5.1.0-SNAPSHOT</blc.version>
         <project.uri>${project.baseUri}</project.uri>
         <attachSources>false</attachSources>
     </properties>

--- a/src/main/java/org/broadleafcommerce/menu/service/MenuServiceImpl.java
+++ b/src/main/java/org/broadleafcommerce/menu/service/MenuServiceImpl.java
@@ -62,19 +62,18 @@ public class MenuServiceImpl implements MenuService {
         List<MenuItemDTO> dtos = new ArrayList<MenuItemDTO>();
         if (CollectionUtils.isNotEmpty(menu.getMenuItems())) {
             for (MenuItem menuItem : menu.getMenuItems()) {
-                dtos.add(convertMenuItemToDTO(menuItem));
+                MenuItemDTO menuItemDTO = convertMenuItemToDTO(menuItem);
+
+                if (menuItemDTO != null) {
+                    dtos.add(menuItemDTO);
+                }
+
             }
         }
         return dtos;
     }
 
     protected MenuItemDTO convertMenuItemToDTO(MenuItem menuItem) {
-
-        Category category = null;
-        if (MenuItemType.CATEGORY.equals(menuItem.getMenuItemType())) {
-            category = catalogService.findCategoryByURI(menuItem.getActionUrl());
-        }
-
         if (MenuItemType.SUBMENU.equals(menuItem.getMenuItemType()) &&
                 menuItem.getLinkedMenu() != null) {
             MenuItemDTO dto = new MenuItemDTO();
@@ -91,8 +90,14 @@ public class MenuServiceImpl implements MenuService {
 
             dto.setSubmenu(submenu);
             return dto;
-        } else if (category != null) {
-            return convertCategoryToMenuItemDTO(category);
+        } else if (MenuItemType.CATEGORY.equals(menuItem.getMenuItemType())) {
+            Category category = catalogService.findCategoryByURI(menuItem.getActionUrl());
+
+            if (category != null) {
+                return convertCategoryToMenuItemDTO(category);
+            } else {
+                return null;
+            }
         } else {
             MenuItemDTO dto = new MenuItemDTO();
             dto.setUrl(menuItem.getDerivedUrl());


### PR DESCRIPTION
BroadleafCommerce/QA#2319

Simple refactoring to ensure that if a category is not found for a CATEGORY menu item, then the item is not put on the menu.