### PR TITLE
Upgrade log4j library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-bom</artifactId>
             <version>2.13.1</version>
-            <scope>import</scope>
+            <scope>compile</scope>
             <type>pom</type>
             <optional>true</optional>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.broadleafcommerce</groupId>
         <artifactId>broadleaf-module-parent</artifactId>
-        <version>1.0.19-SNAPSHOT</version>
+        <version>1.0.18-SNAPSHOT</version>
     </parent>
 
     <groupId>org.broadleafcommerce</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.12</version>
+            <version>1.2.17</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <version>2.1.4-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <blc.version>5.1.19-GA</blc.version>
+        <blc.version>5.1.19-SNAPSHOT</blc.version>
         <project.uri>${project.baseUri}</project.uri>
     </properties>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,32 @@
 
         <!-- Logging -->
         <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-bom</artifactId>
+            <version>2.13.1</version>
+            <scope>import</scope>
+            <type>pom</type>
+            <optional>true</optional>
+        </dependency>
+          <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.13.1</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.13.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.13.1</version>
+            <scope>compile</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <version>1.2.12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <version>2.1.4-SNAPSHOT</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <blc.version>5.1.0-GA</blc.version>
+        <blc.version>5.1.19-GA</blc.version>
         <project.uri>${project.baseUri}</project.uri>
     </properties>
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.broadleafcommerce</groupId>
@@ -21,7 +22,7 @@
         <connection>scm:git:git@github.com:BroadleafCommerce/Menu.git</connection>
         <developerConnection>scm:git:git@github.com:BroadleafCommerce/Menu.git</developerConnection>
         <url>https://github.com/BroadleafCommerce/BroadleafCommerce</url>
-      <tag>HEAD</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <url>http://www.broadleafcommerce.com</url>
@@ -118,7 +119,7 @@
             <type>pom</type>
             <optional>true</optional>
         </dependency>
-          <dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.13.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.broadleafcommerce</groupId>
         <artifactId>broadleaf-module-parent</artifactId>
-        <version>1.0.14-GA</version>
+        <version>1.0.18-SNAPSHOT</version>
     </parent>
 
     <groupId>org.broadleafcommerce</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.broadleafcommerce</groupId>
         <artifactId>broadleaf-module-parent</artifactId>
-        <version>1.0.18-SNAPSHOT</version>
+        <version>1.0.19-SNAPSHOT</version>
     </parent>
 
     <groupId>org.broadleafcommerce</groupId>


### PR DESCRIPTION
Requires:BroadleafCommerce/BroadleafCommerce#2266
**Add proper title**
Do not include issue number on title. State the purpose of this Pull Request. For example:
- Fixes the issue where it was showing incorrect pending changes warning..
- Adding username validation...
- Removing iframe tags from anti-samy cleanse process...
- Updating minification to skip files...

**A Brief Overview**
Upgraded Log4J dependency and references to Log4J2 and made the dependency optional (#1638)
 * Upgraded dependency on log4j to log4j2.  * Deprecated `RuntimeLog4jCofigurer` since log4j is not the default logger and this class was intended for internal use.
 * Update javadoc to use logback as the example of a rolling daily log instead of log4j
 * Make the log4j2 dependency optional and leave log4j in the PomEvaluator. Added license to CheckoutPaymentInfoFormValidator
 * Switched from Log4J to JUL so as to be able to remove `log4j.properties` from project. Also, had to exclude Log4j from ESAPI dependency because HSQLDB will auto-configure itself to use Log4j if found on the classpath.

**Link to QA issue**
QA-3948 - https://github.com/BroadleafCommerce/QA/issues/3948