### PR TITLE
Removed unnecessary logging dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,40 +109,5 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- Logging -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-bom</artifactId>
-            <version>2.13.1</version>
-            <scope>compile</scope>
-            <type>pom</type>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.13.1</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-to-slf4j</artifactId>
-            <version>2.13.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.13.1</version>
-            <scope>compile</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
-            <type>jar</type>
-            <scope>compile</scope>
-        </dependency>
-
     </dependencies>
 </project>


### PR DESCRIPTION
**A Brief Overview**
These were added during last log4j upgrade but these are not required. These will be pulled in from core. Having these here will cause convergence issues.

This is the PR https://github.com/BroadleafCommerce/Menu/pull/35 but his description is copied from https://github.com/BroadleafCommerce/BroadleafCommerce/pull/1638

**Link to QA issue**
https://github.com/BroadleafCommerce/QA/issues/4606